### PR TITLE
ci: use new cargo fmt option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           rustup component add clippy
 
       - name: Check formatting
-        run: cargo fmt -- --check
+        run: cargo fmt --check
 
       - name: Check Clippy
         run: cargo clippy -- -Dwarnings


### PR DESCRIPTION
As of v1.58, cargo fmt now supports the --check flag directly. Updating it here (and in a few other r-l repos) both because it's more succinct and so more people will see/become aware

Clippy was [also failing](https://github.com/rust-lang/rust-repos/runs/4810762989?check_suite_focus=true), presumably due to some clippy changes that occurred since the `Test` job last ran ~17 months ago, so also add 60c80f1e77970623ea9baabf368b803995052915to address the clippy warnings