### PR TITLE
Move simple gitlab scraper to project.

### DIFF
--- a/src/gitlab/mod.rs
+++ b/src/gitlab/mod.rs
@@ -26,6 +26,13 @@ query ListRustRepos($after: String) {
       fullPath
       path
       webUrl
+      repository {
+        cargoFiles: blobs(paths: ["Cargo.toml", "Cargo.lock"] ref: "HEAD") {
+          nodes {
+            path
+          }
+        }
+      }
     }
   }
 }
@@ -46,6 +53,49 @@ struct Project {
     full_path: String,
     path: String,
     web_url: String,
+    repository: Option<Repository>,
+}
+
+impl Project {
+    fn has_cargo_toml(&self) -> bool {
+        match &self.repository {
+            Some(repo) => repo
+                .cargo_files
+                .nodes
+                .iter()
+                .any(|x| x.path == "Cargo.toml"),
+            None => false,
+        }
+    }
+
+    fn has_cargo_lock(&self) -> bool {
+        match &self.repository {
+            Some(repo) => repo
+                .cargo_files
+                .nodes
+                .iter()
+                .any(|x| x.path == "Cargo.lock"),
+            None => false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Repository {
+    cargo_files: FilesNode,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FilesNode {
+    nodes: Vec<FilePath>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FilePath {
+    path: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -61,7 +111,7 @@ struct ApiData {
 }
 
 #[derive(Debug, Deserialize)]
-struct GraphQLResponse {
+struct GraphQlResponse {
     data: Option<ApiData>,
     errors: Option<serde_json::Value>,
 }
@@ -73,18 +123,16 @@ pub fn scrape(data: &Data, config: &Config, should_stop: &AtomicBool) -> Fallibl
     let mut page = 1;
 
     while !should_stop.load(Ordering::SeqCst) {
-        println!("Fetching page {page}...");
-
         let variables = serde_json::json!({ "after": after });
 
-        let resp: GraphQLResponse = client
+        let resp: GraphQlResponse = client
             .post(GITLAB_GRAPHQL_ENDPOINT)
             .json(&serde_json::json!({
                 "query": GRAPHQL_QUERY_REPOSITORIES,
                 "variables": variables
             }))
             .send()?
-            .json()?;
+            .text()?;
 
         if let Some(errors) = resp.errors {
             eprintln!("GraphQL errors: {errors:#?}");
@@ -92,24 +140,21 @@ pub fn scrape(data: &Data, config: &Config, should_stop: &AtomicBool) -> Fallibl
         }
 
         let gitlab_data = resp.data.expect("No data returned");
-        println!("{:?}", gitlab_data);
         let projects = gitlab_data.projects;
 
         for project in projects.nodes {
-            println!("{:?}", project);
             data.store_repo(
                 "gitlab",
                 Repo {
                     id: project.id.clone(),
                     name: project.full_path.to_string(),
-                    has_cargo_toml: true, // TODO set
-                    has_cargo_lock: true,
+                    has_cargo_toml: project.has_cargo_toml(),
+                    has_cargo_lock: project.has_cargo_lock(),
                 },
             )?;
         }
 
         if !projects.page_info.has_next_page {
-            println!("No more pages");
             break;
         }
 

--- a/src/gitlab/mod.rs
+++ b/src/gitlab/mod.rs
@@ -32,9 +32,10 @@ query ListRustRepos($after: String) {
 "#;
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct PageInfo {
-    hasNextPage: bool,
-    endCursor: Option<String>,
+    has_next_page: bool,
+    end_cursor: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -44,17 +45,13 @@ struct Project {
     name: String,
     full_path: String,
     path: String,
-    webUrl: String,
+    web_url: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct Namespace {
-    fullPath: String,
-}
-
-#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct Projects {
-    pageInfo: PageInfo,
+    page_info: PageInfo,
     nodes: Vec<Project>,
 }
 
@@ -111,12 +108,12 @@ pub fn scrape(data: &Data, config: &Config, should_stop: &AtomicBool) -> Fallibl
             )?;
         }
 
-        if !projects.pageInfo.hasNextPage {
+        if !projects.page_info.has_next_page {
             println!("No more pages");
             break;
         }
 
-        after = projects.pageInfo.endCursor;
+        after = projects.page_info.end_cursor;
         page += 1;
     }
 

--- a/src/gitlab/mod.rs
+++ b/src/gitlab/mod.rs
@@ -1,0 +1,113 @@
+use config::Config;
+use data::{Data, Repo};
+use prelude::*;
+use reqwest::blocking::Client;
+use serde::Deserialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+const GITLAB_GRAPHQL_ENDPOINT: &str = "https://gitlab.com/api/graphql";
+
+static USER_AGENT: &str = "rust-repos (https://github.com/rust-ops/rust-repos)";
+
+static GRAPHQL_QUERY_REPOSITORIES: &str = r#"
+query ListRustRepos($after: String) {
+  projects(
+    first: 50
+    after: $after
+    programmingLanguageName: "Rust"
+  ) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      id
+      name
+      path
+      webUrl
+    }
+  }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+struct PageInfo {
+    hasNextPage: bool,
+    endCursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Project {
+    id: String,
+    name: String,
+    path: String,
+    webUrl: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Namespace {
+    fullPath: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Projects {
+    pageInfo: PageInfo,
+    nodes: Vec<Project>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiData {
+    projects: Projects,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQLResponse {
+    data: Option<ApiData>,
+    errors: Option<serde_json::Value>,
+}
+
+pub fn scrape(data: &Data, config: &Config, should_stop: &AtomicBool) -> Fallible<()> {
+    let client = Client::new();
+
+    let mut after: Option<String> = None;
+    let mut page = 1;
+
+    while !should_stop.load(Ordering::SeqCst) {
+        println!("Fetching page {page}...");
+
+        let variables = serde_json::json!({ "after": after });
+
+        let resp: GraphQLResponse = client
+            .post(GITLAB_GRAPHQL_ENDPOINT)
+            .json(&serde_json::json!({
+                "query": GRAPHQL_QUERY_REPOSITORIES,
+                "variables": variables
+            }))
+            .send()?
+            .json()?;
+
+        if let Some(errors) = resp.errors {
+            eprintln!("GraphQL errors: {errors:#?}");
+            break;
+        }
+
+        let data = resp.data.expect("No data returned");
+        println!("{:?}", data);
+        let projects = data.projects;
+
+        let mut last_id = data.get_last_id("gitlab")?.unwrap_or_default();
+        for project in projects.nodes {
+            println!("{:?}", project);
+        }
+
+        if !projects.pageInfo.hasNextPage {
+            println!("No more pages");
+            break;
+        }
+
+        after = projects.pageInfo.endCursor;
+        page += 1;
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ extern crate serde_json;
 mod config;
 mod data;
 mod github;
+mod gitlab;
 mod prelude;
 mod utils;
 
@@ -95,6 +96,7 @@ fn app() -> Fallible<()> {
         stop.store(true, Ordering::SeqCst);
     })?;
 
+    gitlab::scrape(&data, &config, &should_stop)?;
     github::scrape(&data, &config, &should_stop)?;
 
     Ok(())


### PR DESCRIPTION
Currently can generate a correct gitlab csv, but needs further integration and polish. Fixes #20 

Pending work:

- Multi-threading to match the performance of github. But the API seems to be cursor based so maybe not possible (there might be a paginated API to use).
- Integrate into main loop
- Is missing github API token now a hard error if someone just wanted to run gitlab? Integration questions like that